### PR TITLE
Update docs and examples to change "data" to "model"

### DIFF
--- a/docs/module-instantiation.md
+++ b/docs/module-instantiation.md
@@ -23,7 +23,7 @@ When instantiating 'lazily' *FruitMachine* looks at the `module` property and at
 - `id {String}` Your unique id for this View module
 - `module {String}` The module type (only use if using 'Lazy' instantiation)
 - `children {Array}` An array of child views to instantiate (can be lazy JSON or view instances)
-- `data {Object}` A data object that will be accessible in your template
+- `model {Object}` A data model object that will be accessible in your template
 - `helpers {Array}` An array of helper functions to be called on instantiation
 - `classes {Array}` Classes to be added to the root element
 - `template {Function}` A template function that will return HTML (will any existing template)

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -1,6 +1,6 @@
 ## Rendering
 
-When you have [assembled](view-assembly.md) your modules and populated them with the required [data](view-data.md) you can call `.render()`. Render recursively renders the the nested module structure by calling each module's render function, from the bottom up, and then turns the output html string into a DOM node (`view.el`). `Module#render()` (like most module methods) returns the module instance (`this`) to allow for chaining.
+When you have [assembled](layout-assembly.md) your modules and populated them with the required [data](module-instantiation.md#options) you can call `.render()`. Render recursively renders the the nested module structure by calling each module's render function, from the bottom up, and then turns the output html string into a DOM node (`view.el`). `Module#render()` (like most module methods) returns the module instance (`this`) to allow for chaining.
 
 #### Re-rendering
 

--- a/examples/big-collection/script.js
+++ b/examples/big-collection/script.js
@@ -23,7 +23,7 @@ var layout = new LayoutB({
   children: {
     1: {
       module: 'masthead',
-      data: {
+      model: {
         title: 'Big Collection'
       }
     },

--- a/examples/express/build/build.js
+++ b/examples/express/build/build.js
@@ -1079,7 +1079,7 @@ module.exports = function(data) {
 			{
 				id: 'slot_1',
 				module: 'apple',
-				data: {
+				model: {
 					title: data.title
 				}
 			},
@@ -1113,7 +1113,7 @@ module.exports = function(data) {
 			{
 				id: 'slot_1',
 				module: 'apple',
-				data: {
+				model: {
 					title: data.title
 				}
 			},
@@ -1151,7 +1151,7 @@ module.exports = function(data) {
 			{
 				id: 'slot_2',
 				module: 'apple',
-				data: {
+				model: {
 					title: data.title
 				}
 			},

--- a/examples/express/lib/model-section/server.js
+++ b/examples/express/lib/model-section/server.js
@@ -6,7 +6,7 @@ var database = {
       {
         id: 'slot_1',
         module: 'apple',
-        data: {
+        model: {
           title: 'Home'
         }
       }

--- a/examples/express/lib/page-about/view.js
+++ b/examples/express/lib/page-about/view.js
@@ -14,7 +14,7 @@ module.exports = function(data) {
 			{
 				id: 'slot_1',
 				module: 'apple',
-				data: {
+				model: {
 					title: data.title
 				}
 			},

--- a/examples/express/lib/page-home/view.js
+++ b/examples/express/lib/page-home/view.js
@@ -14,7 +14,7 @@ module.exports = function(data) {
 			{
 				id: 'slot_1',
 				module: 'apple',
-				data: {
+				model: {
 					title: data.title
 				}
 			},

--- a/examples/express/lib/page-links/view.js
+++ b/examples/express/lib/page-links/view.js
@@ -18,7 +18,7 @@ module.exports = function(data) {
 			{
 				id: 'slot_2',
 				module: 'apple',
-				data: {
+				model: {
 					title: data.title
 				}
 			},


### PR DESCRIPTION
The "data" argument when instantiating modules has been deprecated in
favour of "model"; update the docs and examples to reflect this new
usage.  Also fix a couple of links on the Rendering documentation page.
