### PR TITLE
Add `before tohtml` event

### DIFF
--- a/lib/module/index.js
+++ b/lib/module/index.js
@@ -472,6 +472,7 @@ module.exports = function(fm) {
    * @api public
    */
   proto.toHTML = function() {
+    this.fireStatic('before tohtml');
     var data = {};
     var html;
     var tmp;

--- a/test/tests/module.toHTML.js
+++ b/test/tests/module.toHTML.js
@@ -7,6 +7,14 @@ buster.testCase('View#toHTML()', {
     assert.isTrue('string' === typeof html);
   },
 
+  "Should fire `before tohtml event`": function() {
+    var spy = this.spy();
+    this.view.on('before tohtml', spy);
+    var html = this.view.toHTML();
+    assert.isTrue('string' === typeof html);
+    assert.called(spy);
+  },
+
   "Should print the child html into the corresponding slot": function() {
     var apple = new Apple({ slot: 1 });
     var layout = new Layout({


### PR DESCRIPTION
When I first added this event it felt a bit hacky and dirty - but it's actually turned out to be really useful as a way of hooking into the data model to add / manipulate data before rendering.  (On initialize doesn't really cut it for data that changes and gets re-rendered often and the `before render` event _only_ runs on the fm module that is being rendered - and doesn't get fired recursively over all of its children)
