### PR TITLE
Correcting syntax error in the Lazy layout example

### DIFF
--- a/docs/layout-assembly.md
+++ b/docs/layout-assembly.md
@@ -21,7 +21,7 @@ orange.children.length; //=> 0
 
 ```js
 var layout = new Layout({
-  children: [
+  children: {
     1: {
       module: 'apple',
       children: {


### PR DESCRIPTION
I'd apply it directly but was unsure whether it should be an array or an object as the keys are numeric. Can the `children` field accept both? or should it be an object with numerical keys?
