### PR TITLE
AT-5109 Fix unauthorised git protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
     "prepublish": "grunt"
   },
   "dependencies": {
-    "evt": "git://github.com/wilsonpage/evt.git",
-    "extend": "git://github.com/wilsonpage/extend.git",
-    "model": "git://github.com/wilsonpage/model.git",
-    "utils": "git://github.com/wilsonpage/utils.git"
+    "evt": "github:wilsonpage/evt",
+    "extend": "github:wilsonpage/extend",
+    "model": "github:wilsonpage/model",
+    "utils": "github:wilsonpage/utils"
   },
   "devDependencies": {
     "backbone": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "evt": "github:wilsonpage/evt",
     "extend": "github:wilsonpage/extend",
-    "model": "github:wilsonpage/model",
+    "model": "github:financial-times/ft-app-model",
     "utils": "github:wilsonpage/utils"
   },
   "devDependencies": {


### PR DESCRIPTION
### Change protocol for dependencies

#### Context:
* Github will stop supporting users connecting via SSH or `git://` on 15th March. 
* There was a brown out on 11th Jan. Example error on CI:
```
npm ERR! Error while executing:
npm ERR! /usr/bin/git ls-remote -h -t git://github.com/wilsonpage/evt.git
npm ERR! 
npm ERR! fatal: remote error: 
npm ERR!   The unauthenticated git protocol on port 9418 is no longer supported.
npm ERR! Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
npm ERR! 
npm ERR! exited with error code: 128
```
* The FT App client is dependent on fruitmachine. 
* Fruitmachine is dependent on a wilson page package that also uses the `git://` protocol. This has been forked and updated here https://github.com/Financial-Times/ft-app-model/pull/1

#### In the PR
* Switch to `github:` shorthand, which (search for github: on https://docs.npmjs.com/cli/v8/commands/npm-install ) uses the git protocol and configuration on the machine npm is running on, which will be git+ssh for us and circleci.
* This approach was trialled by Rowan on the day of the brownout here - https://github.com/Financial-Times/ft-app/pull/1786
* This update will mean we can continue to build the webapp after 15th March
* Reference:
https://github.blog/2021-09-01-improving-git-protocol-security-github/

#### Tests:
N/A but have run npm install locally and the package lock seems to be resolving the dependencies as expected.