### PR TITLE
Ensure package version matches git tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fruitmachine",
   "title": "FruitMachine",
   "description": "A lightweight component layout engine for client and server.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "homepage": "https://github.com/wilsonpage/fruitmachine",
   "author": {
     "name": "Wilson Page",


### PR DESCRIPTION
### Sync git tag and npm package version

* Changes in v1.2.0 git tag were not published to npm when the tag was made. 
* Previous publish (before today) was "1.1.2": "2015-10-16T10:53:31.091Z" - https://registry.npmjs.org/fruitmachine 
* I mistakenly released what should have been git tag v1.2.1 without updating the package version here first so the package version and details in the git tag were not in sync. 
* v1.2.1 has now been released manually so the package versions match git tags again.